### PR TITLE
fix: replace preview mode polling with fixed canvas listener

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,6 +26,9 @@ const config = {
     previewSecret: process.env.UNIFORM_PREVIEW_SECRET || 'unistore',
     outputType: process.env.UNIFORM_OUTPUT_TYPE || 'standard',
   },
+  publicRuntimeConfig: {
+    projectId: process.env.UNIFORM_PROJECT_ID,
+  },
 };
 
 module.exports = withNextPluginPreval(config);

--- a/src/lib/preview/PreviewDevPanel/PreviewEnabler.tsx
+++ b/src/lib/preview/PreviewDevPanel/PreviewEnabler.tsx
@@ -5,7 +5,7 @@ import { RootComponentInstance } from '@uniformdev/canvas';
 
 function PreviewEnabler({ preview, composition }: { preview?: boolean; composition: RootComponentInstance }) {
   const {
-    serverRuntimeConfig: { projectId },
+    publicRuntimeConfig: { projectId },
   } = getConfig();
 
   useLivePreviewNextStaticProps({

--- a/src/lib/preview/PreviewDevPanel/PreviewSwitch/PreviewSwitch.tsx
+++ b/src/lib/preview/PreviewDevPanel/PreviewSwitch/PreviewSwitch.tsx
@@ -1,28 +1,9 @@
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 import getConfig from 'next/config';
 import styles from './PreviewSwitch.module.scss';
 
-// lazy preview function that polls when next preview mode is on,
-// reloading static props every 2s. Need to update this to something that doesn't poll
-// (cross-domain iframe comms?)
-function usePreview(previewing: boolean) {
-  const router = useRouter();
-
-  useEffect(() => {
-    if (!previewing) {
-      return;
-    }
-    const timer = setTimeout(async () => {
-      router.replace(router.asPath, undefined, { scroll: false });
-    }, 2000);
-    return () => clearTimeout(timer);
-  });
-}
-
 function PreviewSwitch({ previewing }: { previewing: boolean }) {
   const router = useRouter();
-  usePreview(previewing);
   const {
     serverRuntimeConfig: { previewSecret },
   } = getConfig();

--- a/src/lib/preview/useLivePreviewNextStaticProps.ts
+++ b/src/lib/preview/useLivePreviewNextStaticProps.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useRouter } from 'next/router';
+import next from 'next';
 import { useCompositionEventEffect, UseCompositionEventEffectOptions } from '@uniformdev/canvas-react';
 
 type UseLivePreviewNextStaticPropsOptions = Omit<UseCompositionEventEffectOptions, 'effect' | 'enabled'>;
@@ -9,6 +10,15 @@ function useLivePreviewNextStaticProps(options: UseLivePreviewNextStaticPropsOpt
 
   const effect = useCallback(() => {
     console.log('🥽 Preview updated.');
+
+    // Fixes preview mode in production
+    // Can be removed after https://github.com/vercel/next.js/issues/37190 is resolved
+    delete (next as any).router.sdc[
+      new URL(
+        `/_next/data/${window.__NEXT_DATA__.buildId}${router.asPath === '/' ? '/index' : router.asPath}.json`,
+        location.href
+      ).toString()
+    ];
     router.replace(router.asPath, undefined, { scroll: false });
   }, [router]);
 


### PR DESCRIPTION
Ref: https://github.com/uniformdev/platform/issues/5111

I have removed the 2-second polling and we now instead use the Canvas change listeners.

Note: You will still see a flash when something changes in Canvas if you have both tabs open. This happens if you have network panel open and "Disable cache" checked - hero image re-renders and has to be re-downloaded as it's not cached.